### PR TITLE
Read client secret optionally from multiple sources

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -49,8 +49,8 @@ type Opts struct {
 }
 
 // in order of precedence, select a source for the client ID or nil
-func clientSecret(context *Context, opts Opts) *string {
-	clientSecret := grab.FirstNonZero(opts.ClientSecret, os.Getenv("CF_OIDC_CLIENT_SECRET"), grab.Value(context.OIDCClientSecret))
+func clientSecret(contextSecret *string, opts Opts) *string {
+	clientSecret := grab.FirstNonZero(opts.ClientSecret, os.Getenv("CF_OIDC_CLIENT_SECRET"), grab.Value(contextSecret))
 	if clientSecret == "" {
 		return nil
 	}
@@ -71,7 +71,7 @@ func New(ctx context.Context, opts Opts) (*Context, error) {
 	current.AccessURL = opts.AccessURL
 	current.OIDCClientID = opts.ClientID
 
-	current.OIDCClientSecret = clientSecret(current, opts)
+	current.OIDCClientSecret = clientSecret(current.OIDCClientSecret, opts)
 
 	current.OIDCIssuer = opts.OIDCIssuer
 
@@ -95,7 +95,7 @@ func NewServerContext(ctx context.Context, opts Opts) (*Context, error) {
 
 		OIDCIssuer: opts.OIDCIssuer,
 	}
-	context.OIDCClientSecret = clientSecret(context, opts)
+	context.OIDCClientSecret = clientSecret(context.OIDCClientSecret, opts)
 
 	// Initialise with an in memory token store to avoid keychain use
 	err := context.Initialize(ctx, InitializeOpts{TokenStore: tokenstore.NewInMemoryTokenStore()})

--- a/config/load.go
+++ b/config/load.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/common-fate/clio"
+	"github.com/common-fate/grab"
 	"github.com/common-fate/sdk/tokenstore"
 )
 
@@ -47,6 +48,14 @@ type Opts struct {
 	OIDCIssuer   string
 }
 
+// in order of precedence, select a source for the client ID or nil
+func clientSecret(context *Context, opts Opts) *string {
+	clientSecret := grab.FirstNonZero(opts.ClientSecret, os.Getenv("CF_OIDC_CLIENT_SECRET"), grab.Value(context.OIDCClientSecret))
+	if clientSecret == "" {
+		return nil
+	}
+	return &clientSecret
+}
 func New(ctx context.Context, opts Opts) (*Context, error) {
 	cfg, err := load()
 	if err != nil {
@@ -61,7 +70,9 @@ func New(ctx context.Context, opts Opts) (*Context, error) {
 	current.APIURL = opts.APIURL
 	current.AccessURL = opts.AccessURL
 	current.OIDCClientID = opts.ClientID
-	current.OIDCClientSecret = &opts.ClientSecret
+
+	current.OIDCClientSecret = clientSecret(current, opts)
+
 	current.OIDCIssuer = opts.OIDCIssuer
 
 	err = current.Initialize(ctx, InitializeOpts{})
@@ -77,13 +88,14 @@ func New(ctx context.Context, opts Opts) (*Context, error) {
 func NewServerContext(ctx context.Context, opts Opts) (*Context, error) {
 
 	context := &Context{
-		APIURL:           opts.APIURL,
-		AccessURL:        opts.AccessURL,
-		AuthzURL:         opts.AuthzURL,
-		OIDCClientID:     opts.ClientID,
-		OIDCClientSecret: &opts.ClientSecret,
-		OIDCIssuer:       opts.OIDCIssuer,
+		APIURL:       opts.APIURL,
+		AccessURL:    opts.AccessURL,
+		AuthzURL:     opts.AuthzURL,
+		OIDCClientID: opts.ClientID,
+
+		OIDCIssuer: opts.OIDCIssuer,
 	}
+	context.OIDCClientSecret = clientSecret(context, opts)
 
 	// Initialise with an in memory token store to avoid keychain use
 	err := context.Initialize(ctx, InitializeOpts{TokenStore: tokenstore.NewInMemoryTokenStore()})

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/common-fate/grab"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_clientSecret(t *testing.T) {
+	type args struct {
+		context *Context
+		opts    Opts
+	}
+	tests := []struct {
+		name   string
+		args   args
+		before func()
+		after  func()
+		want   *string
+	}{
+		{
+			name:   "from env",
+			args:   args{},
+			before: func() { os.Setenv("CF_OIDC_CLIENT_SECRET", "secret") },
+			after:  func() { os.Unsetenv("CF_OIDC_CLIENT_SECRET") },
+			want:   grab.Ptr("secret"),
+		},
+		{
+			name: "from opts",
+			args: args{
+				opts: Opts{
+					ClientSecret: "another secret",
+				},
+			},
+			want: grab.Ptr("another secret"),
+		},
+		{
+			name: "from context",
+			args: args{
+				context: &Context{
+					OIDCClientSecret: grab.Ptr("context"),
+				},
+			},
+			want: grab.Ptr("context"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.before != nil {
+				tt.before()
+			}
+			if tt.after != nil {
+				defer tt.after()
+			}
+			if got := clientSecret(grab.Value(tt.args.context).OIDCClientSecret, tt.args.opts); got != tt.want {
+				assert.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bufbuild/connect-go v1.10.0
 	github.com/common-fate/apikit v0.3.0
 	github.com/common-fate/clio v1.2.3
-	github.com/common-fate/grab v1.0.0
+	github.com/common-fate/grab v1.1.0
 	github.com/fatih/structtag v1.2.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/common-fate/clio v1.2.3 h1:hHwUYZjn66qGYDpgANl0EB/92hyi/Jsnd07qB09rvn
 github.com/common-fate/clio v1.2.3/go.mod h1:NkozaS15SA+6Y9zb+82eIj1i41aWShorTqA01GKQ7A8=
 github.com/common-fate/grab v1.0.0 h1:uRtMdWJcxWHdawIjlI7Q65BFfPrquKKKCiLd6ezfbhQ=
 github.com/common-fate/grab v1.0.0/go.mod h1:L0qa03RwqOMZz9PrrWw9eI145i5FQRf+iLtNSJypQvY=
+github.com/common-fate/grab v1.1.0 h1:HLZPtltdHScYu6qtt/UC78rvwylCTWuyoZoiQXV4QHc=
+github.com/common-fate/grab v1.1.0/go.mod h1:L0qa03RwqOMZz9PrrWw9eI145i5FQRf+iLtNSJypQvY=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Reads in order from 

The order of precedence should be

Directly specifying oidc_client_secret in code - e.g. in the TF provider directly

Lookup from CF_OIDC_CLIENT_SECRET 

Look up from Common Fate ~/commonfate/config file