### PR TITLE
correctly set the context name when loading

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -174,6 +174,11 @@ func openConfigFile(filepath string) (*Config, error) {
 		return nil, err
 	}
 
+	for k, context := range cfg.Contexts {
+		context.name = k
+		cfg.Contexts[k] = context
+	}
+
 	clio.Debugw("loaded config", "cfg", cfg)
 	return &cfg, nil
 }

--- a/tokenstore/token_storage.go
+++ b/tokenstore/token_storage.go
@@ -47,6 +47,7 @@ var (
 // Token returns the token.
 func (s *Storage) Token() (*oauth2.Token, error) {
 	var t oauth2.Token
+	clio.Debugf("attempting to fetch token: %s", s.name)
 	err := s.keyring.Retrieve(s.name, &t)
 	if err != nil {
 		clio.Debugf("error fetching token: %s", err)


### PR DESCRIPTION
Ensures the name is set when loading configuration, which flows through to the keychain for token storage