### PR TITLE
Add generic all method to the entity sdk

### DIFF
--- a/.changeset/sweet-socks-talk.md
+++ b/.changeset/sweet-socks-talk.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": minor
+---
+
+Add additional All methods to the entity package for batch fetching and unmarshalling entity types

--- a/service/entity/list_entities.go
+++ b/service/entity/list_entities.go
@@ -10,7 +10,11 @@ import (
 )
 
 type ListInput struct {
-	Type            string
+	Type string
+	ListOpts
+}
+
+type ListOpts struct {
 	PageToken       string
 	IncludeArchived bool
 	OrderDescending bool
@@ -89,4 +93,20 @@ func (c *Client) All(ctx context.Context, input ListInput) (out []*entityv1alpha
 		return nil
 	})
 	return
+}
+
+// All is a convenience that can be used to fetch all results and unmarshal them into the Type T
+func All[T Entity](ctx context.Context, c *Client, input ListOpts) (out []T, err error) {
+	entities, err := c.All(ctx, ListInput{
+		Type:     (*new(T)).EID().Type,
+		ListOpts: input,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = UnmarshalAll(entities, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/service/entity/list_entities.go
+++ b/service/entity/list_entities.go
@@ -10,17 +10,14 @@ import (
 )
 
 type ListInput struct {
-	Type string
-	ListOpts
-}
-
-type ListOpts struct {
+	Type            string
 	PageToken       string
 	IncludeArchived bool
 	OrderDescending bool
 }
 
 func (c *Client) List(ctx context.Context, input ListInput) (*ListOutput, error) {
+
 	req := &entityv1alpha1.ListRequest{
 		Universe:        "default",
 		Type:            input.Type,
@@ -95,6 +92,12 @@ func (c *Client) All(ctx context.Context, input ListInput) (out []*entityv1alpha
 	return
 }
 
+type ListAllInput struct {
+	PageToken       string
+	IncludeArchived bool
+	OrderDescending bool
+}
+
 // All is a convenience that can be used to fetch all results and unmarshal them into the Type T
 // Example:
 //
@@ -102,10 +105,12 @@ func (c *Client) All(ctx context.Context, input ListInput) (out []*entityv1alpha
 //	if err != nil
 //		return err
 //	}
-func All[T Entity](ctx context.Context, c *Client, input ListOpts) (out []T, err error) {
+func All[T Entity](ctx context.Context, c *Client, input ListAllInput) (out []T, err error) {
 	entities, err := c.All(ctx, ListInput{
-		Type:     (*new(T)).EID().Type,
-		ListOpts: input,
+		Type:            (*new(T)).EID().Type,
+		PageToken:       input.PageToken,
+		IncludeArchived: input.IncludeArchived,
+		OrderDescending: input.OrderDescending,
 	})
 	if err != nil {
 		return nil, err

--- a/service/entity/list_entities.go
+++ b/service/entity/list_entities.go
@@ -91,6 +91,38 @@ type ListOptions struct {
 	OrderDescending bool
 }
 
+// All retrieves all entities of a specified type from the data source.
+//
+// Parameters:
+//
+//	ctx: The context.Context for the request.
+//	c: The *Client object used to make the request.
+//	input: A struct containing options for listing entities, such as pagination, inclusion of archived entities,
+//	       and sorting order.
+//
+// Returns:
+//
+//	[]T: A slice of entities of type T retrieved from the data source.
+//	error: An error, if any, encountered during the retrieval process.
+//
+// Description:
+//
+//	All is a generic function designed to retrieve all entities of a specified type from a data source using a
+//	provided *Client object. The function iterates over pages of entities and unmarshals each entity into the
+//	specified type T, accumulating them into a slice returned to the caller. It handles pagination, error handling,
+//	and other aspects of the retrieval process internally.
+//
+// Example Usage:
+//
+//	entities, err := All[cf.User](ctx, client, ListOptions{
+//	    PageToken:       "some_page_token",
+//	    IncludeArchived: true,
+//	    OrderDescending: false,
+//	})
+//	if err != nil {
+//	    // Handle error
+//	}
+//	// entities will be a slice of type cf.User
 func All[T Entity](ctx context.Context, c *Client, input ListOptions) ([]T, error) {
 	e := *new(T)
 	list := c.ListRequest(ListInput{

--- a/service/entity/list_entities.go
+++ b/service/entity/list_entities.go
@@ -96,6 +96,12 @@ func (c *Client) All(ctx context.Context, input ListInput) (out []*entityv1alpha
 }
 
 // All is a convenience that can be used to fetch all results and unmarshal them into the Type T
+// Example:
+//
+//	users, err := entity.All[cf.User](ctx, c, entity.ListOpts{})
+//	if err != nil
+//		return err
+//	}
 func All[T Entity](ctx context.Context, c *Client, input ListOpts) (out []T, err error) {
 	entities, err := c.All(ctx, ListInput{
 		Type:     (*new(T)).EID().Type,

--- a/service/entity/unmarshal.go
+++ b/service/entity/unmarshal.go
@@ -9,6 +9,18 @@ import (
 	entityv1alpha1 "github.com/common-fate/sdk/gen/commonfate/entity/v1alpha1"
 )
 
+func UnmarshalAll(entities []*entityv1alpha1.Entity, out []Entity) error {
+	for _, ent := range entities {
+		var outType Entity
+		err := Unmarshal(ent, outType)
+		if err != nil {
+			return err
+		}
+		out = append(out, outType)
+	}
+	return nil
+}
+
 func Unmarshal(e *entityv1alpha1.Entity, out Entity) error {
 	v := reflect.ValueOf(out)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {

--- a/service/entity/unmarshal.go
+++ b/service/entity/unmarshal.go
@@ -9,9 +9,9 @@ import (
 	entityv1alpha1 "github.com/common-fate/sdk/gen/commonfate/entity/v1alpha1"
 )
 
-func UnmarshalAll(entities []*entityv1alpha1.Entity, out []Entity) error {
+func UnmarshalAll[T Entity](entities []*entityv1alpha1.Entity, out []T) error {
 	for _, ent := range entities {
-		var outType Entity
+		var outType T
 		err := Unmarshal(ent, outType)
 		if err != nil {
 			return err
@@ -21,7 +21,7 @@ func UnmarshalAll(entities []*entityv1alpha1.Entity, out []Entity) error {
 	return nil
 }
 
-func Unmarshal(e *entityv1alpha1.Entity, out Entity) error {
+func Unmarshal[T Entity](e *entityv1alpha1.Entity, out T) error {
 	v := reflect.ValueOf(out)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("output must be a pointer to a struct")


### PR DESCRIPTION
Updates the entity SDK to add an `All` method to the entity client, this is convenient when you know you want to fetch all pages of results.

Add `UnmarshalAll`, which can be used to unmarshal directly to a list of Entities

Add `All` function which is generic and returns a slice of the given entity type

```go
users, err := entity.All[cf.User](ctx, c, entity.ListOpts{})
if err != nil
    return err
}
```