### PR TITLE
[CF-3007] - Add SDK inputs as attributes to opentelemetry span

### DIFF
--- a/.changeset/unlucky-mice-boil.md
+++ b/.changeset/unlucky-mice-boil.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": patch
+---
+
+Add SDK method inputs to opentelemetry span

--- a/service/entity/list_children.go
+++ b/service/entity/list_children.go
@@ -43,6 +43,7 @@ func (c *Client) ListChildren(ctx context.Context, input ListChildrenInput) (Lis
 	}
 
 	span.SetAttributes(attribute.Int("children_count", len(res.Msg.Children)))
+	span.SetAttributes(attribute.String("parent", input.Parent.ID))
 
 	return out, nil
 }

--- a/service/entity/list_parents.go
+++ b/service/entity/list_parents.go
@@ -43,6 +43,7 @@ func (c *Client) ListParents(ctx context.Context, input ListParentsInput) (ListP
 	}
 
 	span.SetAttributes(attribute.Int("parents_count", len(res.Msg.Parents)))
+	span.SetAttributes(attribute.String("child", input.Child.ID))
 
 	return out, nil
 }


### PR DESCRIPTION
This PR adds the inputs for the list_children and list_parents SDK methods to the opentelemetry spans.