### PR TITLE
allow configing the SDK from environment variables

### DIFF
--- a/.changeset/spotty-hornets-exercise.md
+++ b/.changeset/spotty-hornets-exercise.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": minor
+---
+
+Allow configuring the SDK using environment variables like CF_API_URL, CF_OIDC_CLIENT_ID, and CF_OIDC_CLIENT_SECRET

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.22.0"
+          cache: true
+
+      - name: Lint
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
+          args: --timeout=10m ./...

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -68,6 +69,14 @@ type InitializeOpts struct {
 }
 
 func (c *Context) Initialize(ctx context.Context, opts InitializeOpts) error {
+	// the OIDC client ID and issuer are *always* required, so make sure they've
+	if c.OIDCClientID == "" {
+		return errors.New("OIDC Client ID must be set. You can configure this by setting the CF_OIDC_CLIENT_ID environment variable, or specifying 'oidc_client_id' in the Common Fate config file (~/.cf/config by default). If you're using the Common Fate CLI, use 'cf configure' to set your config file up")
+	}
+	if c.OIDCIssuer == "" {
+		return errors.New("OIDC Issuer must be set. You can configure this by setting the CF_OIDC_ISSUER environment variable, or specifying 'oidc_client_issuer' in the Common Fate config file (~/.cf/config by default). If you're using the Common Fate CLI, use 'cf configure' to set your config file up")
+	}
+
 	emptyClientSecret := ""
 	scopes := []string{"openid", "email"}
 	redirectURI := "http://localhost:18900/auth/callback"

--- a/config/config.go
+++ b/config/config.go
@@ -164,6 +164,8 @@ func (c Config) Current() (*Context, error) {
 func Default() *Config {
 	return &Config{
 		CurrentContext: "",
-		Contexts:       map[string]Context{},
+		Contexts: map[string]Context{
+			"": {},
+		},
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/common-fate/clio/clierr"
@@ -54,6 +55,37 @@ type InitializeOpts struct {
 }
 
 func (c *Context) Initialize(ctx context.Context, opts InitializeOpts) error {
+	// override variables from environment variables, if they are set
+	clientIdEnv := os.Getenv("CF_OIDC_CLIENT_ID")
+	if clientIdEnv != "" {
+		c.OIDCClientID = clientIdEnv
+	}
+
+	clientSecretEnv := os.Getenv("CF_OIDC_CLIENT_SECRET")
+	if clientSecretEnv != "" {
+		c.OIDCClientSecret = &clientSecretEnv
+	}
+
+	oidcIssuerEnv := os.Getenv("CF_OIDC_ISSUER")
+	if oidcIssuerEnv != "" {
+		c.OIDCIssuer = oidcIssuerEnv
+	}
+
+	apiURLEnv := os.Getenv("CF_API_URL")
+	if apiURLEnv != "" {
+		c.APIURL = apiURLEnv
+	}
+
+	accessURLEnv := os.Getenv("CF_ACCESS_URL")
+	if accessURLEnv != "" {
+		c.AccessURL = accessURLEnv
+	}
+
+	authzURLEnv := os.Getenv("CF_AUTHZ_URL")
+	if authzURLEnv != "" {
+		c.AuthzURL = authzURLEnv
+	}
+
 	emptyClientSecret := ""
 	scopes := []string{"openid", "email"}
 	redirectURI := "http://localhost:18900/auth/callback"
@@ -80,8 +112,7 @@ func (c *Context) Initialize(ctx context.Context, opts InitializeOpts) error {
 		cfg := clientcredentials.Config{
 			ClientID:     c.OIDCClientID,
 			ClientSecret: *c.OIDCClientSecret,
-			// Scopes:       []string{"cf.client/machine"},
-			TokenURL: p.OAuthConfig().Endpoint.TokenURL,
+			TokenURL:     p.OAuthConfig().Endpoint.TokenURL,
 		}
 
 		_, err := cfg.Token(ctx)

--- a/config/env_source.go
+++ b/config/env_source.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+type EnvSource struct{}
+
+// Load config variables.
+// The function must not set config variables if they are already set.
+func (ev EnvSource) Load(key Key) string {
+	// turn the key into the environment variable,
+	// e.g. "api_url" becomes "CF_API_URL"
+	envVar := "CF_" + strings.ToUpper(string(key))
+
+	return os.Getenv(envVar)
+}

--- a/config/env_source.go
+++ b/config/env_source.go
@@ -9,10 +9,10 @@ type EnvSource struct{}
 
 // Load config variables.
 // The function must not set config variables if they are already set.
-func (ev EnvSource) Load(key Key) string {
+func (ev EnvSource) Load(key Key) (string, error) {
 	// turn the key into the environment variable,
 	// e.g. "api_url" becomes "CF_API_URL"
 	envVar := "CF_" + strings.ToUpper(string(key))
 
-	return os.Getenv(envVar)
+	return os.Getenv(envVar), nil
 }

--- a/config/file_source.go
+++ b/config/file_source.go
@@ -1,9 +1,10 @@
 package config
 
-import (
-	"github.com/common-fate/clio"
-	"go.uber.org/zap"
-)
+import "errors"
+
+// ErrConfigFileNotFound is returned if the config file (~/.cf/config by default)
+// does not exist.
+var ErrConfigFileNotFound = errors.New("config file does not exist")
 
 type FileSource struct {
 	configFromFile Context
@@ -12,37 +13,35 @@ type FileSource struct {
 
 // Load config variables.
 // The function must not set config variables if they are already set.
-func (s *FileSource) Load(key Key) string {
+func (s *FileSource) Load(key Key) (string, error) {
 	if !s.loaded {
 		s.loaded = true
 		configFromFile, err := load()
 		if err != nil {
-			clio.Debugw("error loading config from file", zap.Error(err))
-			return ""
+			return "", err
 		}
 
 		current, err := configFromFile.Current()
 		if err != nil {
-			clio.Debugw("error loading current config context from file", zap.Error(err))
-			return ""
+			return "", err
 		}
 		s.configFromFile = *current
 	}
 
 	switch key {
 	case APIURLKey:
-		return s.configFromFile.APIURL
+		return s.configFromFile.APIURL, nil
 	case AuthzURLKey:
-		return s.configFromFile.AuthzURL
+		return s.configFromFile.AuthzURL, nil
 	case AccessURLKey:
-		return s.configFromFile.AccessURL
+		return s.configFromFile.AccessURL, nil
 	case OIDCIssuerKey:
-		return s.configFromFile.OIDCIssuer
+		return s.configFromFile.OIDCIssuer, nil
 	case OIDCClientIDKey:
-		return s.configFromFile.OIDCClientID
+		return s.configFromFile.OIDCClientID, nil
 	case OIDCClientSecretKey:
-		return s.configFromFile.OIDCClientSecret
+		return s.configFromFile.OIDCClientSecret, nil
 	}
 
-	return ""
+	return "", nil
 }

--- a/config/file_source.go
+++ b/config/file_source.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"github.com/common-fate/clio"
+	"go.uber.org/zap"
+)
+
+type FileSource struct {
+	configFromFile Context
+	loaded         bool
+}
+
+// Load config variables.
+// The function must not set config variables if they are already set.
+func (s *FileSource) Load(key Key) string {
+	if !s.loaded {
+		s.loaded = true
+		configFromFile, err := load()
+		if err != nil {
+			clio.Debugw("error loading config from file", zap.Error(err))
+			return ""
+		}
+
+		current, err := configFromFile.Current()
+		if err != nil {
+			clio.Debugw("error loading current config context from file", zap.Error(err))
+			return ""
+		}
+		s.configFromFile = *current
+	}
+
+	switch key {
+	case APIURLKey:
+		return s.configFromFile.APIURL
+	case AuthzURLKey:
+		return s.configFromFile.AuthzURL
+	case AccessURLKey:
+		return s.configFromFile.AccessURL
+	case OIDCIssuerKey:
+		return s.configFromFile.OIDCIssuer
+	case OIDCClientIDKey:
+		return s.configFromFile.OIDCClientID
+	case OIDCClientSecretKey:
+		return s.configFromFile.OIDCClientSecret
+	}
+
+	return ""
+}

--- a/config/load.go
+++ b/config/load.go
@@ -19,6 +19,10 @@ import (
 // file for any config values which are not set.
 //
 // The file is ~/.cf/config by default, but this can be overridden with the CF_CONFIG_PATH environment variable.
+//
+// Environment variables follow the pattern 'CF_CONFIG_VARIABLE_NAME', where CONFIG_VARIABLE_NAME
+// is the name of the configuration value in upper snake-case.
+// For example, 'CF_API_URL'.
 func LoadDefault(ctx context.Context) (*Context, error) {
 	return New(ctx, Opts{})
 }
@@ -67,6 +71,36 @@ func loadFromSources(value *string, key Key, sources []configSource) {
 	}
 }
 
+// New creates an initialised SDK context to be used for creating SDK clients.
+// For example:
+//
+//	import "github.com/common-fate/sdk/config"
+//	import "github.com/common-fate/sdk/service/access"
+//
+//	cfg, err := config.New(ctx, opts{})
+//	if err != nil {
+//		return err
+//	}
+//	client := access.NewClient(cfg)
+//
+// Configuration values, such as the API URL and OIDC Client ID to use,
+// can be provided via the Opts{} argument.
+//
+// The New() method will look configuration values up from environment variables
+// and the config file (~/.cf/config by default) if they are not provided in Opts{}.
+// By default, the order of priority is:
+//
+// 1. Static value, set in Opts{}
+//
+// 2. Environment variable
+//
+// 3. Config file
+//
+// This behaviour can be customised by setting opts.ConfigSources.
+//
+// Environment variables follow the pattern 'CF_CONFIG_VARIABLE_NAME', where CONFIG_VARIABLE_NAME
+// is the name of the configuration value in upper snake-case.
+// For example, 'CF_API_URL'.
 func New(ctx context.Context, opts Opts) (*Context, error) {
 	// set up a default config
 	cfg := Context{

--- a/config/load.go
+++ b/config/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -134,14 +135,32 @@ func New(ctx context.Context, opts Opts) (*Context, error) {
 		}
 	}
 
-	loadFromSources(&cfg.APIURL, APIURLKey, sources)
-	loadFromSources(&cfg.AuthzURL, AuthzURLKey, sources)
-	loadFromSources(&cfg.AccessURL, AccessURLKey, sources)
-	loadFromSources(&cfg.OIDCClientID, OIDCClientIDKey, sources)
-	loadFromSources(&cfg.OIDCClientSecret, OIDCClientSecretKey, sources)
-	loadFromSources(&cfg.OIDCIssuer, OIDCIssuerKey, sources)
+	err := loadFromSources(&cfg.APIURL, APIURLKey, sources)
+	if err != nil {
+		return nil, err
+	}
+	err = loadFromSources(&cfg.AuthzURL, AuthzURLKey, sources)
+	if err != nil {
+		return nil, err
+	}
+	err = loadFromSources(&cfg.AccessURL, AccessURLKey, sources)
+	if err != nil {
+		return nil, err
+	}
+	err = loadFromSources(&cfg.OIDCClientID, OIDCClientIDKey, sources)
+	if err != nil {
+		return nil, err
+	}
+	err = loadFromSources(&cfg.OIDCClientSecret, OIDCClientSecretKey, sources)
+	if err != nil {
+		return nil, err
+	}
+	err = loadFromSources(&cfg.OIDCIssuer, OIDCIssuerKey, sources)
+	if err != nil {
+		return nil, err
+	}
 
-	err := cfg.Initialize(ctx, InitializeOpts{TokenStore: opts.TokenStore})
+	err = cfg.Initialize(ctx, InitializeOpts{TokenStore: opts.TokenStore})
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +200,7 @@ func load() (*Config, error) {
 
 	fp := filepath.Join(home, ".cf", "config")
 	cfg, err := openConfigFile(fp)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, ErrConfigFileNotFound
 	}
 	if err != nil {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -7,59 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// func Test_clientSecret(t *testing.T) {
-// 	type args struct {
-// 		context *Context
-// 		opts    Opts
-// 	}
-// 	tests := []struct {
-// 		name   string
-// 		args   args
-// 		before func()
-// 		after  func()
-// 		want   *string
-// 	}{
-// 		{
-// 			name:   "from env",
-// 			args:   args{},
-// 			before: func() { os.Setenv("CF_OIDC_CLIENT_SECRET", "secret") },
-// 			after:  func() { os.Unsetenv("CF_OIDC_CLIENT_SECRET") },
-// 			want:   grab.Ptr("secret"),
-// 		},
-// 		{
-// 			name: "from opts",
-// 			args: args{
-// 				opts: Opts{
-// 					ClientSecret: "another secret",
-// 				},
-// 			},
-// 			want: grab.Ptr("another secret"),
-// 		},
-// 		{
-// 			name: "from context",
-// 			args: args{
-// 				context: &Context{
-// 					OIDCClientSecret: grab.Ptr("context"),
-// 				},
-// 			},
-// 			want: grab.Ptr("context"),
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			if tt.before != nil {
-// 				tt.before()
-// 			}
-// 			if tt.after != nil {
-// 				defer tt.after()
-// 			}
-// 			if got := clientSecret(grab.Value(tt.args.context).OIDCClientSecret, tt.args.opts); got != tt.want {
-// 				assert.EqualValues(t, tt.want, got)
-// 			}
-// 		})
-// 	}
-// }
-
 func Test_loadFromSources(t *testing.T) {
 	type args struct {
 		value   string

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -63,7 +63,10 @@ func Test_loadFromSources(t *testing.T) {
 
 			value := tt.args.value
 
-			loadFromSources(&value, tt.args.key, tt.args.sources)
+			err := loadFromSources(&value, tt.args.key, tt.args.sources)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			assert.Equal(t, tt.want, value)
 		})

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -4,59 +4,121 @@ import (
 	"os"
 	"testing"
 
-	"github.com/common-fate/grab"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_clientSecret(t *testing.T) {
+// func Test_clientSecret(t *testing.T) {
+// 	type args struct {
+// 		context *Context
+// 		opts    Opts
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		args   args
+// 		before func()
+// 		after  func()
+// 		want   *string
+// 	}{
+// 		{
+// 			name:   "from env",
+// 			args:   args{},
+// 			before: func() { os.Setenv("CF_OIDC_CLIENT_SECRET", "secret") },
+// 			after:  func() { os.Unsetenv("CF_OIDC_CLIENT_SECRET") },
+// 			want:   grab.Ptr("secret"),
+// 		},
+// 		{
+// 			name: "from opts",
+// 			args: args{
+// 				opts: Opts{
+// 					ClientSecret: "another secret",
+// 				},
+// 			},
+// 			want: grab.Ptr("another secret"),
+// 		},
+// 		{
+// 			name: "from context",
+// 			args: args{
+// 				context: &Context{
+// 					OIDCClientSecret: grab.Ptr("context"),
+// 				},
+// 			},
+// 			want: grab.Ptr("context"),
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if tt.before != nil {
+// 				tt.before()
+// 			}
+// 			if tt.after != nil {
+// 				defer tt.after()
+// 			}
+// 			if got := clientSecret(grab.Value(tt.args.context).OIDCClientSecret, tt.args.opts); got != tt.want {
+// 				assert.EqualValues(t, tt.want, got)
+// 			}
+// 		})
+// 	}
+// }
+
+func Test_loadFromSources(t *testing.T) {
 	type args struct {
-		context *Context
-		opts    Opts
+		value   string
+		key     Key
+		envVars map[string]string
+		sources []configSource
 	}
 	tests := []struct {
-		name   string
-		args   args
-		before func()
-		after  func()
-		want   *string
+		name string
+		args args
+		want string
 	}{
 		{
-			name:   "from env",
-			args:   args{},
-			before: func() { os.Setenv("CF_OIDC_CLIENT_SECRET", "secret") },
-			after:  func() { os.Unsetenv("CF_OIDC_CLIENT_SECRET") },
-			want:   grab.Ptr("secret"),
+			name: "ok",
+			want: "test",
+			args: args{
+				sources: []configSource{StaticSource{Result: "test"}},
+			},
 		},
 		{
-			name: "from opts",
+			name: "doesnt_override_set_value",
+			want: "existing",
 			args: args{
-				opts: Opts{
-					ClientSecret: "another secret",
-				},
+				value:   "existing",
+				sources: []configSource{StaticSource{Result: "test"}},
 			},
-			want: grab.Ptr("another secret"),
 		},
 		{
-			name: "from context",
+			name: "respects_source_priority",
+			// in this test case, there are two config sources.
+			// we should take the value that we get from the first config source.
+			want: "first",
 			args: args{
-				context: &Context{
-					OIDCClientSecret: grab.Ptr("context"),
-				},
+				sources: []configSource{StaticSource{Result: "first"}, StaticSource{Result: "second"}},
 			},
-			want: grab.Ptr("context"),
+		},
+		{
+			name: "env_var",
+			want: "http://example.com",
+			args: args{
+				envVars: map[string]string{
+					"CF_API_URL": "http://example.com",
+				},
+				key:     APIURLKey,
+				sources: []configSource{EnvSource{}},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.before != nil {
-				tt.before()
+			for k, v := range tt.args.envVars {
+				os.Setenv(k, v)
 			}
-			if tt.after != nil {
-				defer tt.after()
-			}
-			if got := clientSecret(grab.Value(tt.args.context).OIDCClientSecret, tt.args.opts); got != tt.want {
-				assert.EqualValues(t, tt.want, got)
-			}
+
+			value := tt.args.value
+
+			loadFromSources(&value, tt.args.key, tt.args.sources)
+
+			assert.Equal(t, tt.want, value)
 		})
 	}
 }

--- a/config/static_source.go
+++ b/config/static_source.go
@@ -6,6 +6,6 @@ type StaticSource struct {
 
 // Load config variables.
 // The function must not set config variables if they are already set.
-func (s StaticSource) Load(key Key) string {
-	return s.Result
+func (s StaticSource) Load(key Key) (string, error) {
+	return s.Result, nil
 }

--- a/config/static_source.go
+++ b/config/static_source.go
@@ -1,0 +1,11 @@
+package config
+
+type StaticSource struct {
+	Result string
+}
+
+// Load config variables.
+// The function must not set config variables if they are already set.
+func (s StaticSource) Load(key Key) string {
+	return s.Result
+}

--- a/loginflow/loginflow.go
+++ b/loginflow/loginflow.go
@@ -105,17 +105,17 @@ func (lf LoginFlow) Login(ctx context.Context) error {
 				res := string(resWriter.body)
 
 				/*
-Sometimes the nonce will have a value when the auth library is not expecting it, typcally trying to login again fixes the issue. 
-This is a related issue with Entra and the oidc client specifically see https://github.com/zitadel/oidc/issues/509
-					So we have programmed this in and it will make one attempt to retry login before failing.
-					To reproduce the none error, you go to the auth URL either custom like auth.myteam.com or the cognito url cf-auth-words.cognito.com and clear all the cookies
-					Then try to login again, and you should get the nonce error
+					Sometimes the nonce will have a value when the auth library is not expecting it, typcally trying to login again fixes the issue.
+					This is a related issue with Entra and the oidc client specifically see https://github.com/zitadel/oidc/issues/509
+										So we have programmed this in and it will make one attempt to retry login before failing.
+										To reproduce the none error, you go to the auth URL either custom like auth.myteam.com or the cognito url cf-auth-words.cognito.com and clear all the cookies
+										Then try to login again, and you should get the nonce error
 				*/
 				if strings.Contains(res, "failed to exchange token: nonce does not match") {
 					if nonceErrorRetryAttempts != 0 {
 						// Write the original response after 1 retry attempt
 						w.WriteHeader(http.StatusForbidden)
-						w.Write(resWriter.body)
+						_, _ = w.Write(resWriter.body)
 						return
 					}
 					clio.Debugw("Caught a nonce validation error when exchanging code for token and will retry by redirecting to the login page", zap.Error(errors.New(res)))
@@ -125,7 +125,7 @@ This is a related issue with Entra and the oidc client specifically see https://
 
 				clio.Debugw("callback response body", "body", res)
 
-				w.Write(resWriter.body)
+				_, _ = w.Write(resWriter.body)
 				return
 			}
 			h.ServeHTTP(w, r)

--- a/service/authz/batchauthz/testing_test.go
+++ b/service/authz/batchauthz/testing_test.go
@@ -34,7 +34,10 @@ func TestMockBatchWorks(t *testing.T) {
 
 	a.Mock(req, eval)
 
-	a.Authorize(context.Background())
+	err := a.Authorize(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := a.IsPermitted(req)
 	if err != nil {
@@ -62,7 +65,10 @@ func TestMockAnnotations(t *testing.T) {
 
 	a.Allow(principal, resource, action).Annotations("foo", "bar", "other")
 
-	a.Authorize(context.Background())
+	err := a.Authorize(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := a.IsPermitted(authz.Request{Principal: principal, Resource: resource, Action: action})
 	if err != nil {


### PR DESCRIPTION
Updates the SDK to support more general injection of configuration via environment variables.

I've adopted the approach of having 'config sources'. Our current config sources are `file` and `env`, to load from the TOML config file and from environment variables respectively.

To avoid making larger breaking changes I've kept things mostly as they are. Unfortunately this makes the config package a bit messy (we've got stuff in there to deal with saving TOML files, AND to load config from env vars). There is also a risk that we add new config variables and then forget to update the config sources I've added. I've added a comment in the `Context` object to mitigate against this.

A future improvement we can make here is using some kind of reflection and automatically loading from env vars, from the TOML file etc based on some struct tag keys. Packages like [viper](https://github.com/spf13/viper) do exist too but it may be simpler to write our own function.

Also adds testing in GitHub Actions.
