### PR TITLE
Adds support for specifying config sources via the CF_CONFIG_SOURCES environment variable

### DIFF
--- a/.changeset/twelve-rocks-hunt.md
+++ b/.changeset/twelve-rocks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": minor
+---
+
+Adds support for specifying config sources via the CF_CONFIG_SOURCES environment variable.


### PR DESCRIPTION
This is required when using the Common Fate CLI in CI/CD environments, where we want to disable the 'file' config source and configure things entirely using environment variables.