### PR TITLE
Add support for remote config

### DIFF
--- a/.changeset/wicked-carrots-lie-2.md
+++ b/.changeset/wicked-carrots-lie-2.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": patch
+---
+
+The keychain now stores credentials with the key <Issuer URL/Client ID>, rather than the config file context key. This mitigates an issue where using the SDK without the file source would cause invalid credential issues, despite the user having valid credentials for a particular OIDC provider.

--- a/.changeset/wicked-carrots-lie-3.md
+++ b/.changeset/wicked-carrots-lie-3.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": patch
+---
+
+Fix an issue where the config OAuth2.0 token was not updated after the login flow is completed.

--- a/.changeset/wicked-carrots-lie.md
+++ b/.changeset/wicked-carrots-lie.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": minor
+---
+
+Add support for remote configuration of Common Fate SDK by providing a configuration URL.

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/common-fate/clio/clierr"
@@ -90,11 +91,18 @@ func (c *Context) Initialize(ctx context.Context, opts InitializeOpts) error {
 		return err
 	}
 
+	// save the token in the keychain with the key OIDC Issuer + client ID.
+	issuerURL, err := url.Parse(c.OIDCIssuer)
+	if err != nil {
+		return fmt.Errorf("invalid OIDC issuer url: %w", err)
+	}
+	issuerURL = issuerURL.JoinPath(c.OIDCClientID)
+
 	c.OIDCProvider = p
 	c.TokenStore = opts.TokenStore
 	if c.TokenStore == nil {
 		c.TokenStore = grab.Ptr(tokenstore.New(tokenstore.Opts{
-			Name: c.name,
+			Name: issuerURL.String(),
 		}))
 	}
 

--- a/config/env_source.go
+++ b/config/env_source.go
@@ -8,7 +8,6 @@ import (
 type EnvSource struct{}
 
 // Load config variables.
-// The function must not set config variables if they are already set.
 func (ev EnvSource) Load(key Key) (string, error) {
 	// turn the key into the environment variable,
 	// e.g. "api_url" becomes "CF_API_URL"

--- a/config/file_source.go
+++ b/config/file_source.go
@@ -12,7 +12,6 @@ type FileSource struct {
 }
 
 // Load config variables.
-// The function must not set config variables if they are already set.
 func (s *FileSource) Load(key Key) (string, error) {
 	if !s.loaded {
 		s.loaded = true

--- a/config/url_source.go
+++ b/config/url_source.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// URLSource configures Common Fate from a deployment URL.
+// The URL should be a config.json which contains discovery variables
+// for a particular deployment.
+type URLSource struct {
+	DeploymentURL *url.URL
+	configJSON    *URLConfigJSON
+}
+
+// Load config variables.
+func (u *URLSource) Load(key Key) (string, error) {
+	if u.configJSON == nil {
+		err := u.fetchConfig()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	switch key {
+	case APIURLKey:
+		return u.configJSON.APIURL, nil
+	case OIDCClientIDKey:
+		return u.configJSON.CliOAuthClientId, nil
+	case OIDCIssuerKey:
+		return u.configJSON.OAauthIssuer, nil
+	case AccessURLKey:
+		return u.configJSON.AccessAPIURL, nil
+	}
+
+	return "", nil
+}
+
+func (u *URLSource) fetchConfig() error {
+	res, err := http.DefaultClient.Get(u.DeploymentURL.String())
+	if err != nil {
+		return fmt.Errorf("error fetching config from %s: %w", u.DeploymentURL.String(), err)
+	}
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	var cfg URLConfigJSON
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		return err
+	}
+	u.configJSON = &cfg
+	return nil
+}
+
+type URLConfigJSON struct {
+	CliOAuthClientId string `json:"cliOAuthClientId"`
+	OAauthIssuer     string `json:"oauthIssuer"`
+	APIURL           string `json:"apiUrl"`
+	AccessAPIURL     string `json:"accessApiUrl"`
+}

--- a/config/url_source_test.go
+++ b/config/url_source_test.go
@@ -56,7 +56,7 @@ func TestURLSource_Load(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(tt.mockResponse))
+				_, _ = w.Write([]byte(tt.mockResponse))
 			}))
 			defer server.Close()
 

--- a/config/url_source_test.go
+++ b/config/url_source_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestURLSource_Load(t *testing.T) {
+
+	tests := []struct {
+		key          Key
+		name         string
+		mockResponse string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name: "ok",
+			key:  OIDCClientIDKey,
+			mockResponse: `{
+				"oauthClientId": "XXX",
+				"cliOAuthClientId": "YYY",
+				"oauthAuthority": "https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_ABCD/",
+				"oauthIssuer": "https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_ABCD",
+				"apiUrl": "https://commonfate.example.com",
+				"accessApiUrl": "https://commonfate.example.com",
+				"authzGraphApiUrl": "https://commonfate.example.com/graph",
+				"teamName": "Common Fate",
+				"iconUrl": "",
+				"releaseTag": "sha-48b2449"
+			  }`,
+			want: "YYY",
+		},
+		{
+			// should just return an empty string for the client secret
+			name: "ok_for_client_secret_which_is_not_served_by_config_json",
+			key:  OIDCClientSecretKey,
+			mockResponse: `{
+				"oauthClientId": "XXX",
+				"cliOAuthClientId": "YYY",
+				"oauthAuthority": "https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_ABCD/",
+				"oauthIssuer": "https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_ABCD",
+				"apiUrl": "https://commonfate.example.com",
+				"accessApiUrl": "https://commonfate.example.com",
+				"authzGraphApiUrl": "https://commonfate.example.com/graph",
+				"teamName": "Common Fate",
+				"iconUrl": "",
+				"releaseTag": "sha-48b2449"
+			  }`,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(tt.mockResponse))
+			}))
+			defer server.Close()
+
+			depURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			u := &URLSource{
+				DeploymentURL: depURL,
+			}
+			got, err := u.Load(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("URLSource.Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("URLSource.Load() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/loginflow/loginflow.go
+++ b/loginflow/loginflow.go
@@ -167,6 +167,17 @@ func (lf LoginFlow) Login(ctx context.Context) error {
 			return err
 		}
 
+		// reset the OAuth2.0 token source
+		// NOTE(chrnorm): this should be moved to a method on the Context struct to avoid exposing internals
+		src := &tokenstore.NotifyRefreshTokenSource{
+			New:       lf.cfg.OIDCProvider.OAuthConfig().TokenSource(ctx, res.Token),
+			T:         res.Token,
+			SaveToken: lf.cfg.TokenStore.Save,
+		}
+		lf.cfg.TokenSource = src
+
+		lf.cfg.HTTPClient = oauth2.NewClient(ctx, src)
+
 		clio.Successf("Successfully logged in")
 
 		return nil

--- a/tokenstore/notify_token_store.go
+++ b/tokenstore/notify_token_store.go
@@ -26,7 +26,7 @@ func (s *NotifyRefreshTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.T.Valid() {
-		zap.S().Debug("returning cached in-memory token", "expiry", s.T.Expiry.String())
+		zap.S().Debugw("returning cached in-memory token", "expiry", s.T.Expiry.String())
 		return s.T, nil
 	}
 	t, err := s.New.Token()


### PR DESCRIPTION
Adds support for sourcing config from the config.json in a Common Fate deployment.