### PR TITLE
Fix keychain file prompt

### DIFF
--- a/.changeset/small-ghosts-perform.md
+++ b/.changeset/small-ghosts-perform.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": patch
+---
+
+Fix an issue where users were prompted continuously to enter a password when accessing the fallback file keychain in Linux.

--- a/tokenstore/keyring.go
+++ b/tokenstore/keyring.go
@@ -146,7 +146,7 @@ func (s *Keyring) openKeyring() (keyring.Keyring, error) {
 
 		// Fallback encrypted file
 		FileDir:          dirname,
-		FilePasswordFunc: keyring.TerminalPrompt,
+		FilePasswordFunc: keyring.FixedStringPrompt(os.Getenv("CF_KEYRING_FILE_PASSWORD")),
 	}
 
 	kab := os.Getenv("CF_KEYRING_ALLOWED_BACKENDS")


### PR DESCRIPTION
Use an environment variable for the fallback keychain file password, rather than prompting every single time.
