### PR TITLE
Factory service: allow client opts to be provided

### DIFF
--- a/.changeset/polite-bottles-cheat.md
+++ b/.changeset/polite-bottles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/sdk": minor
+---
+
+Factory service: allow connect.ClientOptions to be passed to client constructor

--- a/factory/service/cloudsupport/client.go
+++ b/factory/service/cloudsupport/client.go
@@ -1,10 +1,11 @@
 package cloudsupport
 
 import (
+	"connectrpc.com/connect"
 	"github.com/common-fate/sdk/factoryconfig"
 	"github.com/common-fate/sdk/gen/commonfate/factory/cloudsupport/v1alpha1/cloudsupportv1alpha1connect"
 )
 
-func NewFromConfig(cfg *factoryconfig.Context) cloudsupportv1alpha1connect.CloudSupportServiceClient {
-	return cloudsupportv1alpha1connect.NewCloudSupportServiceClient(cfg.HTTPClient, cfg.BaseURL)
+func NewFromConfig(cfg *factoryconfig.Context, opts ...connect.ClientOption) cloudsupportv1alpha1connect.CloudSupportServiceClient {
+	return cloudsupportv1alpha1connect.NewCloudSupportServiceClient(cfg.HTTPClient, cfg.BaseURL, opts...)
 }

--- a/factory/service/deployment/client.go
+++ b/factory/service/deployment/client.go
@@ -1,10 +1,11 @@
 package deployment
 
 import (
+	"connectrpc.com/connect"
 	"github.com/common-fate/sdk/factoryconfig"
 	"github.com/common-fate/sdk/gen/commonfate/factory/deployment/v1alpha1/deploymentv1alpha1connect"
 )
 
-func NewFromConfig(cfg *factoryconfig.Context) deploymentv1alpha1connect.DeploymentServiceClient {
-	return deploymentv1alpha1connect.NewDeploymentServiceClient(cfg.HTTPClient, cfg.BaseURL)
+func NewFromConfig(cfg *factoryconfig.Context, opts ...connect.ClientOption) deploymentv1alpha1connect.DeploymentServiceClient {
+	return deploymentv1alpha1connect.NewDeploymentServiceClient(cfg.HTTPClient, cfg.BaseURL, opts...)
 }

--- a/factory/service/monitoring/client.go
+++ b/factory/service/monitoring/client.go
@@ -1,22 +1,24 @@
 package monitoring
 
 import (
+	"connectrpc.com/connect"
 	"github.com/common-fate/sdk/factoryconfig"
 	"github.com/common-fate/sdk/gen/commonfate/factory/monitoring/v1alpha1/monitoringv1alpha1connect"
 )
 
 type Client struct {
-	cfg *factoryconfig.Context
+	cfg  *factoryconfig.Context
+	opts []connect.ClientOption
 }
 
-func NewFromConfig(cfg *factoryconfig.Context) *Client {
-	return &Client{cfg: cfg}
+func NewFromConfig(cfg *factoryconfig.Context, opts ...connect.ClientOption) *Client {
+	return &Client{cfg: cfg, opts: opts}
 }
 
 func (c *Client) Tokens() monitoringv1alpha1connect.TokenServiceClient {
-	return monitoringv1alpha1connect.NewTokenServiceClient(c.cfg.HTTPClient, c.cfg.BaseURL)
+	return monitoringv1alpha1connect.NewTokenServiceClient(c.cfg.HTTPClient, c.cfg.BaseURL, c.opts...)
 }
 
 func (c *Client) Validation() monitoringv1alpha1connect.ValidationServiceClient {
-	return monitoringv1alpha1connect.NewValidationServiceClient(c.cfg.HTTPClient, c.cfg.BaseURL)
+	return monitoringv1alpha1connect.NewValidationServiceClient(c.cfg.HTTPClient, c.cfg.BaseURL, c.opts...)
 }

--- a/factory/service/usage/client.go
+++ b/factory/service/usage/client.go
@@ -1,10 +1,11 @@
 package usage
 
 import (
+	"connectrpc.com/connect"
 	"github.com/common-fate/sdk/factoryconfig"
 	"github.com/common-fate/sdk/gen/commonfate/factory/usage/v1alpha1/usagev1alpha1connect"
 )
 
-func NewFromConfig(cfg *factoryconfig.Context) usagev1alpha1connect.UsageServiceClient {
-	return usagev1alpha1connect.NewUsageServiceClient(cfg.HTTPClient, cfg.BaseURL)
+func NewFromConfig(cfg *factoryconfig.Context, opts ...connect.ClientOption) usagev1alpha1connect.UsageServiceClient {
+	return usagev1alpha1connect.NewUsageServiceClient(cfg.HTTPClient, cfg.BaseURL, opts...)
 }


### PR DESCRIPTION
Internal use case is to enable OpenTelemetry tracing for the RPC client libraries.
If rollout works here we can update all clients.
